### PR TITLE
Cancel menu close option

### DIFF
--- a/core/src/main/java/nl/odalitadevelopments/menus/contents/MenuContentsEvents.java
+++ b/core/src/main/java/nl/odalitadevelopments/menus/contents/MenuContentsEvents.java
@@ -1,13 +1,14 @@
 package nl.odalitadevelopments.menus.contents;
 
+import nl.odalitadevelopments.menus.contents.action.MenuCloseResult;
 import nl.odalitadevelopments.menus.contents.placeableitem.PlaceableItemClickAction;
 import nl.odalitadevelopments.menus.contents.placeableitem.PlaceableItemDragAction;
 import nl.odalitadevelopments.menus.contents.placeableitem.PlaceableItemShiftClickAction;
 import org.bukkit.event.inventory.InventoryClickEvent;
-import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 public sealed interface MenuContentsEvents permits MenuContentsEventsImpl {
 
@@ -19,7 +20,11 @@ public sealed interface MenuContentsEvents permits MenuContentsEventsImpl {
 
     void onPlayerInventoryClick(@NotNull Consumer<@NotNull InventoryClickEvent> eventConsumer);
 
-    void onClose(boolean beforePlaceableItemRemoveAction, @NotNull Runnable action);
+    void onClose(boolean beforeUnregisteringMenu, @NotNull Supplier<@NotNull MenuCloseResult> action);
+
+    void onClose(@NotNull Supplier<@NotNull MenuCloseResult> action);
+
+    void onClose(boolean beforeUnregisteringMenu, @NotNull Runnable action);
 
     void onClose(@NotNull Runnable action);
 }

--- a/core/src/main/java/nl/odalitadevelopments/menus/contents/MenuContentsEventsImpl.java
+++ b/core/src/main/java/nl/odalitadevelopments/menus/contents/MenuContentsEventsImpl.java
@@ -1,6 +1,7 @@
 package nl.odalitadevelopments.menus.contents;
 
 import lombok.AllArgsConstructor;
+import nl.odalitadevelopments.menus.contents.action.MenuCloseResult;
 import nl.odalitadevelopments.menus.contents.placeableitem.PlaceableItemClickAction;
 import nl.odalitadevelopments.menus.contents.placeableitem.PlaceableItemDragAction;
 import nl.odalitadevelopments.menus.contents.placeableitem.PlaceableItemShiftClickAction;
@@ -8,6 +9,7 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 @AllArgsConstructor
 final class MenuContentsEventsImpl implements MenuContentsEvents {
@@ -51,16 +53,29 @@ final class MenuContentsEventsImpl implements MenuContentsEvents {
     }
 
     @Override
-    public void onClose(boolean beforePlaceableItemRemoveAction, @NotNull Runnable action) {
+    public void onClose(boolean beforeUnregisteringMenu, @NotNull Supplier<@NotNull MenuCloseResult> action) {
         if (this.menuContents.menuFrameData() != null) {
             throw new UnsupportedOperationException("Close event is not supported in frames.");
         }
 
-        if (beforePlaceableItemRemoveAction) {
+        if (beforeUnregisteringMenu) {
             this.menuContents.cache.setCloseActionBefore(action);
         } else {
             this.menuContents.cache.setCloseActionAfter(action);
         }
+    }
+
+    @Override
+    public void onClose(@NotNull Supplier<@NotNull MenuCloseResult> action) {
+        this.onClose(true, action);
+    }
+
+    @Override
+    public void onClose(boolean beforeUnregisteringMenu, @NotNull Runnable action) {
+        this.onClose(beforeUnregisteringMenu, () -> {
+            action.run();
+            return MenuCloseResult.CLOSE;
+        });
     }
 
     @Override

--- a/core/src/main/java/nl/odalitadevelopments/menus/contents/MenuContentsImpl.java
+++ b/core/src/main/java/nl/odalitadevelopments/menus/contents/MenuContentsImpl.java
@@ -494,6 +494,8 @@ sealed class MenuContentsImpl implements MenuContents permits MenuFrameContentsI
     @Override
     public void registerPlaceableItemSlots(int... slots) {
         for (int slot : slots) {
+            if (!this.menuSession.fits(slot)) continue;
+
             this.cache.getPlaceableItems().add(slot);
         }
     }

--- a/core/src/main/java/nl/odalitadevelopments/menus/contents/action/MenuCloseResult.java
+++ b/core/src/main/java/nl/odalitadevelopments/menus/contents/action/MenuCloseResult.java
@@ -1,0 +1,7 @@
+package nl.odalitadevelopments.menus.contents.action;
+
+public enum MenuCloseResult {
+
+    KEEP_OPEN,
+    CLOSE
+}

--- a/core/src/main/java/nl/odalitadevelopments/menus/listeners/InventoryListener.java
+++ b/core/src/main/java/nl/odalitadevelopments/menus/listeners/InventoryListener.java
@@ -2,6 +2,7 @@ package nl.odalitadevelopments.menus.listeners;
 
 import lombok.AllArgsConstructor;
 import nl.odalitadevelopments.menus.OdalitaMenus;
+import nl.odalitadevelopments.menus.contents.action.MenuCloseResult;
 import nl.odalitadevelopments.menus.contents.placeableitem.PlaceableItemClickAction;
 import nl.odalitadevelopments.menus.contents.placeableitem.PlaceableItemDragAction;
 import nl.odalitadevelopments.menus.contents.placeableitem.PlaceableItemShiftClickAction;
@@ -12,6 +13,7 @@ import nl.odalitadevelopments.menus.menu.MenuProcessor;
 import nl.odalitadevelopments.menus.menu.MenuSession;
 import nl.odalitadevelopments.menus.menu.type.SupportedMenuType;
 import nl.odalitadevelopments.menus.utils.BukkitThreadHelper;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -21,6 +23,7 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.*;
+import java.util.function.Supplier;
 
 @AllArgsConstructor
 public final class InventoryListener implements Listener {
@@ -204,9 +207,13 @@ public final class InventoryListener implements Listener {
 
         Inventory inventory = event.getInventory();
         if (menuSession.getInventory().equals(inventory)) {
-            Runnable closeActionBefore = menuSession.getCache().getCloseActionBefore();
+            Supplier<MenuCloseResult> closeActionBefore = menuSession.getCache().getCloseActionBefore();
             if (closeActionBefore != null) {
-                closeActionBefore.run();
+                // If the close action is to keep the menu open, open the inventory again
+                if (closeActionBefore.get() == MenuCloseResult.KEEP_OPEN) {
+                    Bukkit.getScheduler().runTask(this.instance.getJavaPlugin(), () -> player.openInventory(inventory));
+                    return;
+                }
             }
 
             PlaceableItemsCloseAction action = menuSession.getCache().getPlaceableItemsCloseAction();
@@ -223,9 +230,13 @@ public final class InventoryListener implements Listener {
                 }
             }
 
-            Runnable closeActionAfter = menuSession.getCache().getCloseActionAfter();
+            Supplier<MenuCloseResult> closeActionAfter = menuSession.getCache().getCloseActionAfter();
             if (closeActionAfter != null) {
-                closeActionAfter.run();
+                // If the close action is to keep the menu open, reopen the menu
+                if (closeActionAfter.get() == MenuCloseResult.KEEP_OPEN) {
+                    Bukkit.getScheduler().runTask(this.instance.getJavaPlugin(), menuSession::reopen);
+                    // Don't return here, because we still want to close the previous menu session
+                }
             }
 
             menuSession.setClosed(true);

--- a/core/src/main/java/nl/odalitadevelopments/menus/menu/MenuInitializer.java
+++ b/core/src/main/java/nl/odalitadevelopments/menus/menu/MenuInitializer.java
@@ -38,7 +38,7 @@ final class MenuInitializer<P extends MenuProvider> {
             Inventory inventory = menuType.createInventory(inventoryTitle);
 
             String menuId = (annotation.id().isEmpty() || annotation.id().isBlank()) ? null : annotation.id();
-            MenuSession menuSession = new MenuSession(this.menuProcessor.getInstance(), player, menuId, menuType, inventory, annotation.title(), annotation.globalCacheKey());
+            MenuSession menuSession = new MenuSession(this.menuProcessor.getInstance(), this.builder, player, menuId, menuType, inventory, annotation.title(), annotation.globalCacheKey());
 
             MenuContents contents = menuSession.getMenuContents();
             this.builder.getProviderLoader().load(menuProvider, player, contents);

--- a/core/src/main/java/nl/odalitadevelopments/menus/menu/MenuSession.java
+++ b/core/src/main/java/nl/odalitadevelopments/menus/menu/MenuSession.java
@@ -28,6 +28,8 @@ import java.util.Map;
 public final class MenuSession {
 
     private final OdalitaMenus instance;
+    @Getter(AccessLevel.NONE)
+    private final MenuOpenerBuilderImpl<?> builder;
     private final Player player;
 
     private String id;
@@ -50,8 +52,9 @@ public final class MenuSession {
 
     private final Collection<Runnable> openActions = Sets.newConcurrentHashSet();
 
-    MenuSession(OdalitaMenus instance, Player player, String id, SupportedMenuType menuType, Inventory inventory, String title, String globalCacheKey) {
+    MenuSession(OdalitaMenus instance, MenuOpenerBuilderImpl<?> builder, Player player, String id, SupportedMenuType menuType, Inventory inventory, String title, String globalCacheKey) {
         this.instance = instance;
+        this.builder = builder;
         this.player = player;
 
         this.id = id;
@@ -146,6 +149,11 @@ public final class MenuSession {
     @ApiStatus.Internal
     public void setClosed(boolean closed) {
         this.closed = closed;
+    }
+
+    @ApiStatus.Internal
+    public void reopen() {
+        this.builder.open();
     }
 
     public int getRows() {

--- a/core/src/main/java/nl/odalitadevelopments/menus/menu/cache/MenuSessionCache.java
+++ b/core/src/main/java/nl/odalitadevelopments/menus/menu/cache/MenuSessionCache.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.Setter;
 import nl.odalitadevelopments.menus.contents.MenuFrameData;
 import nl.odalitadevelopments.menus.contents.MenuTask;
+import nl.odalitadevelopments.menus.contents.action.MenuCloseResult;
 import nl.odalitadevelopments.menus.contents.action.PlayerInventoryItemMetaChanger;
 import nl.odalitadevelopments.menus.contents.placeableitem.PlaceableItemClickAction;
 import nl.odalitadevelopments.menus.contents.placeableitem.PlaceableItemDragAction;
@@ -49,8 +50,8 @@ public final class MenuSessionCache {
     private PlaceableItemDragAction placeableItemDragAction = null;
 
     private Consumer<InventoryClickEvent> playerInventoryClickAction = null;
-    private Runnable closeActionBefore = null;
-    private Runnable closeActionAfter = null;
+    private Supplier<MenuCloseResult> closeActionBefore = null;
+    private Supplier<MenuCloseResult> closeActionAfter = null;
 
     private PlayerInventoryItemMetaChanger itemMetaChanger = null;
 


### PR DESCRIPTION
In #7, an inquiry was made regarding the availability of an option to prevent menu closure. As this feature was not previously included, I have incorporated it into this pull request.

Two new onClose methods have been introduced to `MenuContentsEvents`, each equipped with a supplier to provide a MenuCloseResult. This new `MenuCloseResult` encompasses two enum constants: `KEEP_OPEN` and `CLOSE`, whose purposes are self-explanatory.

When returning the enum constant `KEEP_OPEN` prior to handling unregister logic (the default behavior), the menu will simply reopen with the same cache, pagination pages, events, etc. If `KEEP_OPEN` is returned after handling unregister logic, the menu will reopen with all settings restored to their initial state.

The existing onClose event methods remain intact and do not necessitate a return of MenuCloseResult. They will function equivalently to returning `CLOSE` in the new event methods.