### PR TITLE
Fix InventoryClickEvent not registering (in some cases??)

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -149,6 +149,11 @@
                             <pattern>org.bukkit.craftbukkit.v1_21_R2</pattern>
                             <shadedPattern>org.bukkit.craftbukkit</shadedPattern>
                         </relocation>
+                        <!-- Required if testing (locally) on 1.21.4 -->
+                        <relocation>
+                            <pattern>org.bukkit.craftbukkit.v1_21_R3</pattern>
+                            <shadedPattern>org.bukkit.craftbukkit</shadedPattern>
+                        </relocation>
                     </relocations>
                 </configuration>
                 <executions>

--- a/core/src/main/java/nl/odalitadevelopments/menus/listeners/InventoryListener.java
+++ b/core/src/main/java/nl/odalitadevelopments/menus/listeners/InventoryListener.java
@@ -32,7 +32,7 @@ public final class InventoryListener implements Listener {
     private final OdalitaMenus instance;
     private final MenuProcessor menuProcessor;
 
-    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.LOWEST)
     public void onInventoryClick(InventoryClickEvent event) {
         Player player = (Player) event.getWhoClicked();
         MenuSession menuSession = this.menuProcessor.getOpenMenuSession(player);

--- a/core/src/main/java/nl/odalitadevelopments/menus/listeners/InventoryListener.java
+++ b/core/src/main/java/nl/odalitadevelopments/menus/listeners/InventoryListener.java
@@ -32,7 +32,7 @@ public final class InventoryListener implements Listener {
     private final OdalitaMenus instance;
     private final MenuProcessor menuProcessor;
 
-    @EventHandler(priority = EventPriority.LOWEST)
+    @EventHandler(priority = EventPriority.LOW)
     public void onInventoryClick(InventoryClickEvent event) {
         Player player = (Player) event.getWhoClicked();
         MenuSession menuSession = this.menuProcessor.getOpenMenuSession(player);


### PR DESCRIPTION
Unfortunately I couldn't find the real reason why this happened with #29 and no one else.
Maybe an issue with hardware? It could be so fast the event has no time to be called because it's already cancelled?? 

Also added 1.21.4 to the maven shade.